### PR TITLE
Enhanced OS independent CPU and FPU detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ IF NOT WARN
 The tool is already quite useable, but there are still some things missing, which I want to fix in future versions (no particular order):
 
 - Add ``$RTG`` variable to enable/disable stuff like FBlit or swap screen mode configurations
-~~- For Os 1.3: add detection for CPUs > 68020 and at least the 68882~~
+- ~~For Os 1.3: add detection for CPUs > 68020 and at least the 68882~~
 - Make use of boards.library and identify.library if available for even more expansions.
 - Make a WinUAE/FS-UAE-based test suite for automated tests (CI/CD-like)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Currently, the following variables are supported:
 | **``$SlowRamFirst``** | see&nbsp;description | The variable is set to ``1`` if Slow RAM is first to be allocated as non-Chip RAM[^2], otherwise this variable is unavailable
 | **``$KickVer``** & **``$KickRev``** | always | Kickstart version and revision (see [limitations](#Kickstart-12-and-below))
 | **``$BSDSockLib``**, **``$BSDSockLibVer``**, **``$BSDSockLibRev``** | if&nbsp;present | ID, version and revision of bsdsocket.library
+| **``$Emu``**| if&nbsp;detected | emulation, one of ``UAE``, ``Musashi``, ``Emu68``
 | **``$UAEMajor``**, **``$UAEMinor``**, **``$UAERev``** | if&nbsp;detected | major, minor version and revision of UAE detected (see [limitations](#UAE-detection))
 | **``$VampireType``** | if&nbsp;CPU&nbsp;=&nbsp;68080 | type of vampire installed, for example "V2_600", or "V4_Standalone"
 | **``$VampireCoreRev``** | if&nbsp;CPU&nbsp;=&nbsp;68080 | core revision of the currently flashed firmware .jic file[^3]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently, the following variables are supported:
 |--------------|------------------------------------------|------------------------------------------
 | **``$CPU``** | always | installed CPU, for example ``68030``
 | **``$FPU``** | always | installed FPU, one of ``68881``, ``68882``, ``internal``, or ``none`` for LC/EC 040 and 060 CPUs where no FPU is available
+| **``$CPURev``** | always | Revision of installed CPU for MC68060/MC68LC060/MC68EC060 and AC68080, for example ``6``
 | **``$Chipset``** | always | installed graphics chipset, one of ``OCS``, ``ECS``, ``AGA``, ``SAGA``
 | **``$VFreq``** | always | vertical frequency of the native display, can be either ``50`` (PAL 50Hz) or ``60`` (NTSC 60Hz)
 | **``$TotalChipRam``** | always | total amount of Chip RAM installed (in KB)
@@ -21,7 +22,7 @@ Currently, the following variables are supported:
 | **``$SlowRamFirst``** | see&nbsp;description | The variable is set to ``1`` if Slow RAM is first to be allocated as non-Chip RAM[^2], otherwise this variable is unavailable
 | **``$KickVer``** & **``$KickRev``** | always | Kickstart version and revision (see [limitations](#Kickstart-12-and-below))
 | **``$BSDSockLib``**, **``$BSDSockLibVer``**, **``$BSDSockLibRev``** | if&nbsp;present | ID, version and revision of bsdsocket.library
-| **``$Emu``**| if&nbsp;detected | emulation, one of ``UAE``, ``Musashi``, ``Emu68``
+| **``$Emulation``**| if&nbsp;detected | emulation, one of ``UAE``, ``Musashi``, ``Emu68``
 | **``$UAEMajor``**, **``$UAEMinor``**, **``$UAERev``** | if&nbsp;detected | major, minor version and revision of UAE detected (see [limitations](#UAE-detection))
 | **``$VampireType``** | if&nbsp;CPU&nbsp;=&nbsp;68080 | type of vampire installed, for example "V2_600", or "V4_Standalone"
 | **``$VampireCoreRev``** | if&nbsp;CPU&nbsp;=&nbsp;68080 | core revision of the currently flashed firmware .jic file[^3]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Currently, the following variables are supported:
 <a name="overview_table"></a>
 |Variable|Availability|Description
 |--------------|------------------------------------------|------------------------------------------
-| **``$CPU``** | always | installed CPU, for example ``68030`` (68080 is supported, but see [limitations](#Kickstart-13-and-below))
-| **``$FPU``** | if&nbsp;CPU&nbsp;≥&nbsp;68020 | installed FPU, one of ``68881``, ``68882``, ``internal``, or empty for LC/EC 040 and 060 CPUs where no FPU is available (see [limitations](#Kickstart-13-and-below))
+| **``$CPU``** | always | installed CPU, for example ``68030``
+| **``$FPU``** | if&nbsp;CPU&nbsp;≥&nbsp;68020 | installed FPU, one of ``68881``, ``68882``, ``internal``, or ``none`` for LC/EC 040 and 060 CPUs where no FPU is available
 | **``$Chipset``** | always | installed graphics chipset, one of ``OCS``, ``ECS``, ``AGA``, ``SAGA``
 | **``$VFreq``** | always | vertical frequency of the native display, can be either ``50`` (PAL 50Hz) or ``60`` (NTSC 60Hz)
 | **``$TotalChipRam``** | always | total amount of Chip RAM installed (in KB)
@@ -84,7 +84,6 @@ The tool is also available in the [Aminet](https://aminet.net) and there is a [s
 As sysvars is optimized for speed, being compact and system friendly, it is not an elaborate H/W detection tool, such as WhichAmiga. This means that there might be system combinations, where sysvars gets it wrong. Some known limititaions are listed below. Anyway, you can always file a bug report, if you think that sysvars can be optimized.
 
 ## Kickstart 1.3 and below
-- Sysvars currently detects CPUs above 68020 as 68020 and any FPUs as 68881.
 - Environment variables can only have global scope (i.e., they reside in ENV:). This means you must have ENV: mounted (e.g., to some folder on RAM:). This is not required for OS 2.0 and above.
 - Environment variables can only be used with the IF command (things like
   ``ECHO $CPU`` do not work. You must use ``IF $CPU GE 68010``).
@@ -132,7 +131,7 @@ IF NOT WARN
 The tool is already quite useable, but there are still some things missing, which I want to fix in future versions (no particular order):
 
 - Add ``$RTG`` variable to enable/disable stuff like FBlit or swap screen mode configurations
-- For Os 1.3: add detection for CPUs > 68020 and at least the 68882
+~~- For Os 1.3: add detection for CPUs > 68020 and at least the 68882~~
 - Make use of boards.library and identify.library if available for even more expansions.
 - Make a WinUAE/FS-UAE-based test suite for automated tests (CI/CD-like)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, the following variables are supported:
 |Variable|Availability|Description
 |--------------|------------------------------------------|------------------------------------------
 | **``$CPU``** | always | installed CPU, for example ``68030``
-| **``$FPU``** | if&nbsp;CPU&nbsp;≥&nbsp;68020 | installed FPU, one of ``68881``, ``68882``, ``internal``, or ``none`` for LC/EC 040 and 060 CPUs where no FPU is available
+| **``$FPU``** | always | installed FPU, one of ``68881``, ``68882``, ``internal``, or ``none`` for LC/EC 040 and 060 CPUs where no FPU is available
 | **``$Chipset``** | always | installed graphics chipset, one of ``OCS``, ``ECS``, ``AGA``, ``SAGA``
 | **``$VFreq``** | always | vertical frequency of the native display, can be either ``50`` (PAL 50Hz) or ``60`` (NTSC 60Hz)
 | **``$TotalChipRam``** | always | total amount of Chip RAM installed (in KB)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Currently, the following variables are supported:
 |Variable|Availability|Description
 |--------------|------------------------------------------|------------------------------------------
 | **``$CPU``** | always | installed CPU, for example ``68030``
-| **``$FPU``** | always | installed FPU, one of ``68881``, ``68882``, ``internal``, or ``none`` for LC/EC 040 and 060 CPUs where no FPU is available
-| **``$CPURev``** | always | Revision of installed CPU for MC68060/MC68LC060/MC68EC060 and AC68080, for example ``6``
+| **``$FPU``** | if&nbsp;present | installed FPU, one of ``68881``, ``68882`` or ``internal``
+| **``$CPURev``** | if&nbsp;available | Revision of installed CPU for MC68060/MC68LC060/MC68EC060 and AC68080, for example ``6``
 | **``$Chipset``** | always | installed graphics chipset, one of ``OCS``, ``ECS``, ``AGA``, ``SAGA``
 | **``$VFreq``** | always | vertical frequency of the native display, can be either ``50`` (PAL 50Hz) or ``60`` (NTSC 60Hz)
 | **``$TotalChipRam``** | always | total amount of Chip RAM installed (in KB)
@@ -22,7 +22,7 @@ Currently, the following variables are supported:
 | **``$SlowRamFirst``** | see&nbsp;description | The variable is set to ``1`` if Slow RAM is first to be allocated as non-Chip RAM[^2], otherwise this variable is unavailable
 | **``$KickVer``** & **``$KickRev``** | always | Kickstart version and revision (see [limitations](#Kickstart-12-and-below))
 | **``$BSDSockLib``**, **``$BSDSockLibVer``**, **``$BSDSockLibRev``** | if&nbsp;present | ID, version and revision of bsdsocket.library
-| **``$Emulation``**| if&nbsp;detected | emulation, one of ``UAE``, ``Musashi``, ``Emu68``
+| **``$Emulation``**| if&nbsp;present | emulation, one of ``UAE``, ``Musashi``, ``Emu68``
 | **``$UAEMajor``**, **``$UAEMinor``**, **``$UAERev``** | if&nbsp;detected | major, minor version and revision of UAE detected (see [limitations](#UAE-detection))
 | **``$VampireType``** | if&nbsp;CPU&nbsp;=&nbsp;68080 | type of vampire installed, for example "V2_600", or "V4_Standalone"
 | **``$VampireCoreRev``** | if&nbsp;CPU&nbsp;=&nbsp;68080 | core revision of the currently flashed firmware .jic file[^3]

--- a/source/sysvars.S
+++ b/source/sysvars.S
@@ -1,6 +1,6 @@
 ************************************************************
 *                                                          *
-*                      SYSVARS V.0.18                      *
+*                      SYSVARS V.0.19                      *
 *                                                          *
 * SPDX-FileCopyrightText: (c) 2023-2025 Lars Stockmann     *
 * SPDX-License-Identifier: MIT                             *
@@ -13,7 +13,7 @@
 ************************************************************
 
 PROGVER: macro
-    dc.b "$VER: SYSVARS 0.18",0
+    dc.b "$VER: SYSVARS 0.19",0
     endm
 
 ******************** Feature Selection *********************
@@ -744,15 +744,22 @@ setCPUAndFPUEnvVars:
     rte
 
 .line1111Trap:
+    cmp.l   #CPU_68000,d7
+    beq.s   .fourwordframe
     cmp.l   #CPU_68040,d7
     blo.s   .sixwordframe
 ; MC68EC040 and MC68LC040 Floating-Point Unimplemented Stack Frame, Format $4
 .eightwordframe
     add.l   #$10,sp
     bra.s   .cleanup
-; all other cpus without fpu generate 6 word stack frames on exception (Six-Word Stack Frame, Format $2)
+; all other cpus except 68000 without fpu generate 6 word stack frames on exception
+; (Six-Word Stack Frame, Format $2)
 .sixwordframe
     addq.l  #$8,sp
+    bra.s   .cleanup
+; 68000 generates 4 word stack frames on exception (Four-Word Stack Frame, Format $0)
+.fourwordframe
+    addq.l  #$6,sp
     bra.s   .cleanup
 
     section "VariableData",DATA

--- a/source/sysvars.S
+++ b/source/sysvars.S
@@ -113,6 +113,8 @@ CACRF_NAI EQU 1<<14
 CACRB_IE EQU 15
 CACRF_IE EQU 1<<15
 
+AC68080_ID EQU $0440
+
 ; Exec Constants and _LVOs
 
 EXEC_BASE      =  4
@@ -475,6 +477,25 @@ setCPUAndFPUEnvVars:
 
 ; D4 gets the CPU version as ASCII character that replaces
 ; the "?" in "680?0"
+
+; Based on code by
+
+; Chris Hooper: detecting MC680x0 cpus by cleverly
+; exploiting their CACR and PCR capabilities
+; https://github.com/cdhooper/amigapci_stm32/blob/main/amiga/cpu_control.c
+
+; Photon: call a function in supervisor mode and use
+; dc.w to allow compiling with 68000 function set
+; http://coppershade.org/asmskool/PhotonsMiniStartup/PhotonsMiniWrapper1.04!.S
+
+; Markus Wandel: providing Kickstart 1.2 disassembly to ensure
+; that - and how - MC68010 and MC68020 detection is done
+; https://wandel.ca/homepage/execdis/exec_disassembly.txt
+
+; Apollo AC68080 PROGRAMMER'S REFERENCE MANUAL
+; telling the MC68060 and AC68080 apart by its PCR ID value
+; http://www.apollo-core.com/documentation/AC68080PRM.pdf
+
     moveq #"0",d4           ; assume 68000
     btst #0,d5              ; test for 68010+
     beq.s .storeCPU         ; it's 68000
@@ -482,29 +503,36 @@ setCPUAndFPUEnvVars:
     btst #1,d5              ; test for 68020+
     beq.s .storeCPU         ; it's 68010
     moveq #"2",d4           ; assume 68020
-    move.l #CACRF_IE,d1     ; CACR value to enable 68040+ instruction cache
+    move.l #CACRF_IE,d1     ; CACR value to enable 68040+
+                            ; instruction cache
     lea .writeCACR(pc),a5   ; fetch pointer to function
-    jsr _LVOSupervisor(a0)  ; execute function in supervisor mode
+    jsr _LVOSupervisor(a0)  ; execute function in supervisor
+                            ; mode
     btst #CACRB_IE,d1       ; test for 68040
     bne.s .is040
-    move.l #CACRF_ED,d1      ; CACR value to enable 68030 data cache
-    jsr _LVOSupervisor(a0)  ; execute function in supervisor mode
+    move.l #CACRF_ED,d1     ; CACR value to enable 68030
+                            ; data cache
+    jsr _LVOSupervisor(a0)  ; execute function in
+                            ; supervisor mode
     btst #CACRB_ED,d1
     beq.s .storeCPU         ; it's 68020
     moveq #"3",d4
     bra.s .storeCPU         ; it's 68030
 .is040:
     moveq #"4",d4           ; assume 68040
-    move.l #CACRF_NAI,d1      ; CACR value to enable 68060 no allocation mode
-    jsr _LVOSupervisor(a0)  ; execute function in supervisor mode
+    move.l #CACRF_NAI,d1    ; CACR value to enable 68060
+                            ; no allocation mode
+    jsr _LVOSupervisor(a0)  ; execute function in
+                            ; supervisor mode
     btst #CACRB_NAI,d1
     beq.s .storeCPU         ; it's 68040
     moveq #"6",d4           ; assume 68060
     lea .readPCR(pc),a5     ; fetch pointer to function
-    jsr _LVOSupervisor(a0)  ; execute function in supervisor mode
+    jsr _LVOSupervisor(a0)  ; execute function in
+                            ; supervisor mode
     swap d1
     and.l #$0000FFF0,d1
-    cmp.w #$0440,d1
+    cmp.w #AC68080_ID,d1
     bne.s .storeCPU         ; it's 68060
     moveq #"8",d4           ; it's 68080
 

--- a/source/sysvars.S
+++ b/source/sysvars.S
@@ -1,6 +1,6 @@
 ************************************************************
 *                                                          *
-*                      SYSVARS V.0.20                      *
+*                      SYSVARS V.0.21                      *
 *                                                          *
 * SPDX-FileCopyrightText: (c) 2023-2025 Lars Stockmann     *
 * SPDX-License-Identifier: MIT                             *
@@ -13,7 +13,7 @@
 ************************************************************
 
 PROGVER: macro
-    dc.b "$VER: SYSVARS 0.20",0
+    dc.b "$VER: SYSVARS 0.21",0
     endm
 
 ******************** Feature Selection *********************
@@ -1266,9 +1266,14 @@ musashi_interaction_pid equ $6b
 	moveq #musashi_interaction_pid,d1
     jsr _LVOFindConfigDev(a6)
     tst.l d0
-    beq.s .restoreA6
+    beq.s .closeExpansion
 
     SET_ENV_VAR_CLEN Emu,#MusashiStr,7
+
+.closeExpansion:
+    movea.l a6,a1
+    movea.l EXEC_BASE.w,a6
+    jsr _LVOCloseLibrary(a6)
 
 .restoreA6:
     movea.l a4,a6

--- a/source/sysvars.S
+++ b/source/sysvars.S
@@ -1,6 +1,6 @@
 ************************************************************
 *                                                          *
-*                      SYSVARS V.0.21                      *
+*                      SYSVARS V.0.23                      *
 *                                                          *
 * SPDX-FileCopyrightText: (c) 2023-2025 Lars Stockmann     *
 * SPDX-License-Identifier: MIT                             *
@@ -13,7 +13,7 @@
 ************************************************************
 
 PROGVER: macro
-    dc.b "$VER: SYSVARS 0.21",0
+    dc.b "$VER: SYSVARS 0.23",0
     endm
 
 ******************** Feature Selection *********************
@@ -30,6 +30,7 @@ E_\1 = 0
     ; DISABLE KickRev
 
     ; DISABLE CPU
+    ; DISABLE CPURev
     ; DISABLE FPU
 
     ; DISABLE Chipset
@@ -45,6 +46,7 @@ E_\1 = 0
     ; DISABLE BSDSockLibRev
     ; DISABLE BSDSockLib
 
+    ; DISABLE Emulation
     ; DISABLE UAEMajor
     ; DISABLE UAEMinor
     ; DISABLE UAERev
@@ -73,6 +75,7 @@ E_\1 = 1
     CHECK_ENABLED KickRev
 
     CHECK_ENABLED CPU
+    CHECK_ENABLED CPURev
     CHECK_ENABLED FPU
 
     CHECK_ENABLED Chipset
@@ -88,8 +91,7 @@ E_\1 = 1
     CHECK_ENABLED BSDSockLibRev
     CHECK_ENABLED BSDSockLib
 
-    CHECK_ENABLED Emu
-
+    CHECK_ENABLED Emulation
     CHECK_ENABLED UAEMajor
     CHECK_ENABLED UAEMinor
     CHECK_ENABLED UAERev
@@ -126,6 +128,11 @@ FPU_68881   EQU 1
 FPU_68882   EQU 2
 FPU_INT     EQU 3
 
+EMU_NONE    EQU 0
+EMU_UAE     EQU 1
+EMU_MUSASHI EQU 2
+EMU_EMU68   EQU 3
+
 ; processor configuration register disable floating-point unit (68060)
 PCRB_DPF EQU 1
 PCRF_DPF EQU 1<<1
@@ -143,6 +150,11 @@ CACRB_IE EQU 15
 CACRF_IE EQU 1<<15
 
 AC68080_ID EQU $0440
+MC68060_ID EQU $0430
+
+; constants for detection of 24bit addressing
+KICK_VER equ $00F8000C
+KICK_VER_WRAP equ 1<<24
 
 ; Exec Constants and _LVOs
 
@@ -151,9 +163,20 @@ EXEC_Node_SIZE = 14
 EXEC_LIB_HDR_S = EXEC_Node_SIZE+20
 EXEC_O_LIB_VER = EXEC_Node_SIZE+6
 
+; exec.library
 _LVOSupervisor = -30
-_LVOOpenLibrary  = -552
+_LVOFindName     = -276
 _LVOCloseLibrary = -414
+_LVOOpenResource = -498
+_LVOOpenLibrary  = -552
+
+_LVOResourceList = $150
+
+; expansion.library
+_LVOFindConfigDev = -72
+musashi_mid equ $7db
+musashi_interaction_pid equ $6b
+
 
 _LVOAttnFlags = $128
 
@@ -209,7 +232,7 @@ SET_ENV_VAR: macro
             moveq #0,d3
         endc
         bsr    setEnvVar
-        bne    .setVarDone\@
+        bne.b  .setVarDone\@
         move.l #\1EnvVarName,d1      ; print error
         bsr    printErrorMsg
         moveq  #0,d0                 ; indicate error
@@ -448,7 +471,7 @@ _LVOSoftVer   = $14
 
     lea    KS_END,a0
     suba.l KS_END_OFFSET_LEN(a0),a0  ; Subtract KS length
-    adda.w #KS_VER_OFFSET,a0
+    lea    KS_VER_OFFSET(a0),a0
     moveq  #0,d5                     ; clean D5
     moveq  #0,d6                     ; clean D6
     move.w (a0)+,d5                  ; KickVer --> D5
@@ -480,7 +503,7 @@ _LVOSoftVer   = $14
 
 *********************** CPU and FPU ************************
 
-    if E_CPU+E_FPU
+    if E_CPU+E_FPU+E_CPURev
     
     section "Code",CODE
 
@@ -499,30 +522,23 @@ _LVOSoftVer   = $14
 ; Potentially overwrites all registers, except A6
 ;-----------------------------------------------------------
 setCPUAndFPUEnvVars:
-
-    movea.l EXEC_BASE.w,a0          ; get exec base in A0
-
+    ; detect CPU
+    movea.l EXEC_BASE.w,a0  ; get exec base in A0
     lea .detectCPU(pc),a5   ; fetch pointer to function
     jsr _LVOSupervisor(a0)  ; execute function in supervisor
                             ; mode
+    lea .cpuType,a3
+    move.b d7,(a3)
 
-    move.l  d0,d7           ; store cpu model for later
-
-; D0 gets the CPU version as ASCII character that replaces
-; the "?" in "680?0"
-    lea     .cpuDigit,a0
-    move.b  (a0,d0),d0
-    addi.l  #$30,d0         ; convert to ascii
-    move.b  d0,CPUStr+3     ; digit at position 3
-    SET_ENV_VAR_CLEN CPU,#CPUStr,5
-
-    movea.l EXEC_BASE.w,a0    ; get exec base in A0
+    ; detect FPU
+    movea.l EXEC_BASE.w,a0  ; get exec base in A0
     move.l  d7,d1           ; recall cpu model
     lea .detectFPU(pc),a5
     jsr _LVOSupervisor(a0)
 
 ; D0 gets the FPU version as ASCII character that replaces
 ; the "?" in "6888?" or the whole string gets mangled
+.writeFPUString:
     lea     FPUStr,a0
     cmp.l   #FPU_NONE,d0
     beq.s   .fpuNone
@@ -536,6 +552,11 @@ setCPUAndFPUEnvVars:
     moveq   #5,d3
     bra.s   .setFPUEnvVar
 .fpuNone:
+    ; 68040 without FPU are LC/EC variants
+    cmp.b   #CPU_68040,(a3)
+    bne.s   .noCPUModelAdjust
+    move.b  #CPU_68LC040,(a3)
+.noCPUModelAdjust
     move.l  #"none",(a0)
     moveq   #4,d3
     bra.s   .setFPUEnvVar
@@ -545,18 +566,48 @@ setCPUAndFPUEnvVars:
 .setFPUEnvVar:
     SET_ENV_VAR FPU,#FPUStr,d3
 
+.writeCPUString:
+    moveq   #0,d7
+    move.b  (a3),d7
+    move.l  d7,d0
+    mulu.w  #.cpuNameLength,d0
+    lea     .cpuName,a0
+    adda.l  d0,a0
+    SET_ENV_VAR CPU,a0
+
+    cmp.b #CPU_68040,d7
+    ble.s .end
+    ; set CPU revision for MC68060/AC68080
+    SET_NUMERIC_ENV_VAR CPURev,d6
+
+.end
     rts
 
     section "VariableData",DATA
-
-.cpuDigit:
-    dc.b 0,1,2,2,3,3,4,4,4,6,6,6,8
+.cpuType:
+    dc.b 0
+    cnop 0,2
+.cpuNameLength EQU 8
+.cpuName:
+    dc.b "68000",0,0,0
+    dc.b "68010",0,0,0
+    dc.b "68EC020",0
+    dc.b "68020",0,0,0
+    dc.b "68EC030",0
+    dc.b "68030",0,0,0
+    dc.b "68EC040",0
+    dc.b "68LC040",0
+    dc.b "68040",0,0,0
+    dc.b "68EC060",0
+    dc.b "68LC060",0
+    dc.b "68060",0,0,0
+    dc.b "68080",0
     cnop 0,2
 
     section "Code",CODE
 
 ;-----------------------------------------------------------
-; Determines the CPU type and returns it in register D0
+; Determines the CPU type
 ; This function must be called in supervisor mode
 ;
 ; Based on code by
@@ -577,7 +628,9 @@ setCPUAndFPUEnvVars:
 ; http://www.apollo-core.com/documentation/AC68080PRM.pdf
 ;
 ;-----------------------------------------------------------
-; OUT: D0 - CPU type
+; OUT: D7 - CPU type
+;      D6 - CPU revision (MC68060/AC68080 only)
+;
 ;-----------------------------------------------------------
 ; Note: Doesn't preserve any registers
 ;-----------------------------------------------------------
@@ -621,26 +674,45 @@ setCPUAndFPUEnvVars:
                             ; data cache
     jsr     .writeCACR(pc)
     btst    #CACRB_ED,d1
-    beq.s   .detectCPU_end  ; it's 68020
+    bne.s   .is030          ; it's 68030
+	; it's 68020 or 68ec020
+	; get kickstart version
+	movea.l #KICK_VER,a3
+	; and from same address with bit 24 set
+	; which wraps around on MC68EC020
+	movea.l #KICK_VER_WRAP,a4
+	add.l a3,a4
+	move.l (a3),d3
+	move.l (a4),d4
+	; compare kickstart versions
+	cmp.l d3,d4
+	bne.s .detectCPU_end
+	moveq #CPU_68EC020,d7
+    bra.s .detectCPU_end
+.is030:
     moveq   #CPU_68030,d7
     bra.s   .detectCPU_end  ; it's 68030
 
 .is040:
     moveq   #CPU_68040,d7   ; assume 68040
-    move.l  #CACRF_NAI,d1   ; CACR value to enable 68060
-                            ; no allocation mode
-    jsr     .writeCACR(pc)
-
-    btst    #CACRB_NAI,d1
-    beq.s   .detectCPU_end  ; it's 68040
-    moveq   #CPU_68060,d7   ; assume 68060
     dc.w    $4e7a,$1808     ; hex for 'movec.l pcr, d1 ; read pcr
 
-    swap d1
-    and.l   #$0000FFF0,d1
+    ; store revision
+    moveq   #0,d6
+    move.w  d1,d6
+    lsr.w   #8,d6
+    ; it's either MC68060 or AC68080
+    moveq   #CPU_68080,d7   ; assume 68080
+    clr.w   d1
+    swap    d1
     cmp.w   #AC68080_ID,d1
-    bne.s   .detectCPU_end  ; it's 68060
-    moveq   #CPU_68080,d7   ; it's 68080
+    beq.s   .detectCPU_end  ; it's 68080
+    moveq   #CPU_68060,d7   ; assume 68060
+    andi.l  #$0000000F,d1
+    tst.l   d1
+    beq.s   .detectCPU_end
+    moveq   #CPU_68LC060,d7   ; it's 68LC060 or 68EC060
+    bra.s   .detectCPU_end
 
 .cleanupCPU
     ; restore Illegal Instruction vector on absolute address
@@ -657,7 +729,6 @@ setCPUAndFPUEnvVars:
     move.l  d1,a1
     move.l  d5,IllegalInstructionVector(a1)
 .detectCPU_end
-    move.l  d7,d0
     rte
 
 .illegalInstructionTrap:
@@ -752,7 +823,7 @@ setCPUAndFPUEnvVars:
     blo.s   .sixwordframe
 ; MC68EC040 and MC68LC040 Floating-Point Unimplemented Stack Frame, Format $4
 .eightwordframe
-    add.l   #$10,sp
+    lea     $10(sp),sp
     bra.s   .cleanup
 ; all other cpus except 68000 without fpu generate 6 word stack frames on exception
 ; (Six-Word Stack Frame, Format $2)
@@ -776,6 +847,7 @@ FPUStr: dc.b "6888rnal"
     section "Strings",CODE
 
     DEFINE_ENV_VAR CPU
+    DEFINE_ENV_VAR CPURev
     DEFINE_ENV_VAR FPU    
 
     endc
@@ -819,11 +891,11 @@ VAMP_VER_ADDR      = $dff3fc
 
     moveq  #0,d0
     move.w VAMP_CORE_REV_ADDR,d0
-    beq    .setCoreRevNotAvailable  ; 0 is invalid
-    bmi    .setCoreRevNotAvailable  ; negative is invalid
+    beq.b  .setCoreRevNotAvailable  ; 0 is invalid
+    bmi.b  .setCoreRevNotAvailable  ; negative is invalid
 
     SET_NUMERIC_ENV_VAR VampireCoreRev,d0
-    bra    .processClockMultAndVersion
+    bra.b   .processClockMultAndVersion
 
 .setCoreRevNotAvailable:
     SET_ENV_VAR_CLEN VampireCoreRev,#VAMP_CORE_REV_NA,-1
@@ -845,9 +917,9 @@ VAMP_VER_ADDR      = $dff3fc
     lea    VAMP_TYPE_OFFSETS,a1 ; we need the offsets later
     lsr.w  #8,d4                ; get higher 8 bits for type
     subq.b #1,d4                ; constants start at 1
-    bmi    .setVampType         ; if < 0, print unknown
+    bmi.b  .setVampType         ; if < 0, print unknown
     cmpi.b #VAMP_TYPE_COUNT,d4  ; compare against type count 
-    bge    .setVampType         ; if greater, print unknown
+    bge.b  .setVampType         ; if greater, print unknown
     lea    VAMP_TYPE_STRINGS,a0 ; valid type, A0 -> strings
     move.b (a1,d4),d4           ; nth (D4) offset into D4
     adda   d4,a0                ; Add offset (D4) to A0
@@ -1057,7 +1129,7 @@ mh_Upper      = $18
     ; Now test if slow ram came first (total fast ram = 0)
     tst.l d5
     ; if not remove the SlowRamFirst variable
-    bne   .removeSlowRamFirstVariable
+    bne.b .removeSlowRamFirstVariable
     ; otherwise set this variable to '1' (D3 is the length)
     moveq #1,d3
     SET_ENV_VAR SlowRamFirst,#_SlowRamFirstVal,d3
@@ -1149,7 +1221,7 @@ setBSDSockLibEnvVars:
 
 .copyIdString:
     move.b (a1)+,(a0)+
-    bne    .copyIdString
+    bne.b  .copyIdString
 
     CLOSE_LIBRARY a4,a5
     ; Set variables
@@ -1179,7 +1251,7 @@ BSDSockLibName: dc.b "bsdsocket.library",0
 
 **************************** UAE ***************************
 
-    if E_UAEMajor+E_UAEMinor+E_UAERev
+    if E_UAEMajor+E_UAEMinor+E_UAERev+E_Emulation
     
     section "Code",CODE
 ;-----------------------------------------------------------
@@ -1197,110 +1269,152 @@ BSDSockLibName: dc.b "bsdsocket.library",0
 ; Potentially overwrites all registers, except A6
 ;-----------------------------------------------------------
 setUAEEnvVars:
-_LVOFindConfigDev EQU -72
-_LVOOpenResource EQU -498
-_LVOResourceList = $150
-_LVOFindName     = -276
-musashi_mid equ $7db
-musashi_interaction_pid equ $6b
-
+    ; save dos.library pointer
     movea.l a6,a4
+    ; get exec.library
     movea.l EXEC_BASE.w,a6
+
+    ; assume no emulation
+    moveq #EMU_NONE,d7
 
 ; try to open UAE's uae.resource
     moveq #0,d0
-    lea UaeResName,a1
+    lea .UaeResName,a1
     jsr _LVOOpenResource(a6)
     tst.l d0
     beq.w .notUAE
 
+    ; it's UAE
+    moveq #EMU_UAE,d7
+
 ; UAE structure embeds a library structure, after that it
 ; holds three words: major,; minor and revision
-.readUAEVersions:
-    lea     _LVOResourceList(a6),a0  ; arg1 resource list
-    lea     UaeResName,a1            ; arg2 resource name
-    jsr     _LVOFindName(a6)         ; call FindName
-    movea.l a4,a6                    ; restore A6
+    move.l d0,a3                ; addr. of UAE struct in A2
+    lea EXEC_LIB_HDR_S(a3),a3   ; add precalculated offset
 
-; Store version as string in UAEEnvVarCont    
-    move.l  d0,a3               ; addr. of UAE struct in A2
-    adda    #EXEC_LIB_HDR_S,a3  ; add precalculated offset
+; Get UAE version information
+    lea .UAEVersions,a0
+    ; UAE major version
+    move.w (a3)+,(a0)+
+    ; UAE minor version
+    move.w (a3)+,(a0)+
+    ; UAE revision
+    move.w (a3)+,(a0)+
 
-    moveq  #0,d0
-    move.w (a3)+,d0
-    SET_NUMERIC_ENV_VAR UAEMajor,d0
-    moveq  #0,d0
-    move.w (a3)+,d0
-    SET_NUMERIC_ENV_VAR UAEMinor,d0
-    moveq  #0,d0
-    move.w (a3)+,d0
-    SET_NUMERIC_ENV_VAR UAERev,d0
-    SET_ENV_VAR_CLEN Emu,#UAEStr,3
-    bra.w .exit
+    bra.w .writeEmuEnvVars
 
 .notUAE:
-    DELETE_ENV_VAR UAEMajor
-    DELETE_ENV_VAR UAEMinor
-    DELETE_ENV_VAR UAERev
-
 ; try to open Emu68's devicetree.resource
-    lea Emu68ResName,a1
+    moveq #0,d0
+    lea .Emu68ResName,a1
     jsr _LVOOpenResource(a6)
     tst.l d0
     beq.s .notEmu68
 
-    SET_ENV_VAR_CLEN Emu,#Emu68Str,5
-    bra.s .restoreA6
+    ; it's Emu68
+    moveq #EMU_EMU68,d7
+    bra.w .writeEmuEnvVars
 
 .notEmu68:
 ; try to find Musashi's interaction device
     moveq #0,d0
-    lea.l expansionName,a1
+    lea.l .expansionName,a1
     jsr _LVOOpenLibrary(a6)
     tst.l d0
     ; quit if expansion.library couldn't be opened
-    beq.s .restoreA6
+    beq.s .writeEmuEnvVars
 
+    ; move expansion.library pointer
     movea.l d0,a6
+    suba.l a0,a0
 	move.l #musashi_mid,d0
 	moveq #musashi_interaction_pid,d1
     jsr _LVOFindConfigDev(a6)
     tst.l d0
     beq.s .closeExpansion
 
-    SET_ENV_VAR_CLEN Emu,#MusashiStr,7
+    ; it's Musashi
+    moveq #EMU_MUSASHI,d7
 
 .closeExpansion:
+    ; get expansion.library pointer
     movea.l a6,a1
     movea.l EXEC_BASE.w,a6
     jsr _LVOCloseLibrary(a6)
 
-.restoreA6:
+.writeEmuEnvVars
+    ; restore dos.library pointer
     movea.l a4,a6
+
+    cmp.b #EMU_NONE,d7
+    ; no emulation found
+    beq.w .deleteUAE
+
+.checkUAE
+    cmp.b #EMU_UAE,d7
+    bne.w .checkEmu68
+
+    ; write UAE emulation environment variables
+    lea .UAEVersions,a3
+    moveq #0,d0
+    move.w (a3)+,d0
+    SET_NUMERIC_ENV_VAR UAEMajor,d0
+    moveq #0,d0
+    move.w (a3)+,d0
+    SET_NUMERIC_ENV_VAR UAEMinor,d0
+    moveq #0,d0
+    move.w (a3)+,d0
+    SET_NUMERIC_ENV_VAR UAERev,d0
+    SET_ENV_VAR_CLEN Emulation,#.UAEStr,3
+    bra.s .exit
+
+.checkEmu68
+    cmp.b #EMU_EMU68,d7
+    bne.s .checkMusashi
+
+    ; write Emu68 emulation environment variables
+    SET_ENV_VAR_CLEN Emulation,#.Emu68Str,5
+    bra.s .deleteUAE
+
+.checkMusashi
+    cmp.b #EMU_MUSASHI,d7
+    bne.s .deleteUAE
+
+    ; write Musashi emulation environment variables
+    SET_ENV_VAR_CLEN Emulation,#.MusashiStr,7
+    ; fall through
+
+.deleteUAE:
+    DELETE_ENV_VAR UAEMajor
+    DELETE_ENV_VAR UAEMinor
+    DELETE_ENV_VAR UAERev
+
 .exit
     rts
 
     section "Strings",CODE
-expansionName:
+.expansionName:
     dc.b "expansion.library",0
     cnop 0,2
-UaeResName:
+.UaeResName:
     dc.b "uae.resource",0
     cnop 0,2
-Emu68ResName:
+.Emu68ResName:
     dc.b "devicetree.resource",0
     cnop 0,2
-UAEStr:
+.UAEVersions:
+    dcb.w 3,0
+.UAEStr:
     dc.b "UAE"
     cnop 0,2
-MusashiStr:
+.MusashiStr:
     dc.b "Musashi"
     cnop 0,2
-Emu68Str:
+.Emu68Str:
     dc.b "Emu68"
     cnop 0,2
 
-    DEFINE_ENV_VAR Emu
+    DEFINE_ENV_VAR Emulation
     DEFINE_ENV_VAR UAEMajor
     DEFINE_ENV_VAR UAEMinor
     DEFINE_ENV_VAR UAERev
@@ -1381,9 +1495,9 @@ printNumber:
 
 ; Generate string from right to left, starting right before
 ; _PrintedNumberEnd
-    lea .retFromDiv,a0
+    lea .retFromDiv(pc),a0
 .loop:
-    bra    ldiv10
+    bra.b  ldiv10
 .retFromDiv:
     LMUL10 d0,d1
     sub.l  d1,d3    ; get remainder
@@ -1420,7 +1534,7 @@ strlen:
     move.l a1,d0  ; preserve the start address
 .testNT:
     tst.b (a1)+    ; test character
-    bne   .testNT  ; if not '\0', back to testNT
+    bne.b .testNT  ; if not '\0', back to testNT
     subq  #1,a1    ; back to the null terminator
     sub.l a1,d0
     neg.l d0
@@ -1444,7 +1558,7 @@ GetEnvVarPath:
 
 ; 1. get total length of env variable path
     move.l d1,a1   ; arg1 for strlen
-    bsr    strlen  ; get length in D0
+    bsr.b  strlen  ; get length in D0
     suba.l d0,a1   ; restore A1 to start of name
     addq.b #5,d0   ; Add 5 (for "ENV:" and '\0')
 
@@ -1481,7 +1595,7 @@ GetEnvVarPath:
 ;         D2.l - address of content string
 ;         D3.l - Content length, -1 for null-terminated string
 ; OUT:    D0.l - TRUE (-1) if successful, FALSE (0) if not
-; IN/OUT: D6.l - Reference to dos.library
+; IN/OUT: A6.l - Reference to dos.library
 ;-----------------------------------------------------------
 ; Overwrites D0, D1, A0, A1
 ;-----------------------------------------------------------
@@ -1495,8 +1609,8 @@ MODE_NEWFILE = 1006
 
     movem.l d2-d5/a2,-(sp) ; preserve registers
 
-    lea .createFile,a0  ; return address in A0
-    bra GetEnvVarPath
+    lea .createFile(pc),a0  ; return address in A0
+    bra.b GetEnvVarPath
 
 .createFile
 ; 3. Create file at env path
@@ -1558,7 +1672,7 @@ MODE_NEWFILE = 1006
 ;         D2.l - address of content string
 ;         D3.l - Content length, -1 for null-terminated string
 ; OUT:    D0.l - TRUE (-1) if successful, FALSE (0) if not
-; IN/OUT: D6.l - Reference to dos.library
+; IN/OUT: A6.l - Reference to dos.library
 ;-----------------------------------------------------------
 ; Overwrites D0, D1, A0, A1
 ;-----------------------------------------------------------
@@ -1581,7 +1695,7 @@ _LVODeleteVar = -912
 ;-----------------------------------------------------------
 ; IN      D1.l - address of null-terminated env. var. name
 ; OUT:    D0.l - TRUE (-1) if successful, FALSE (0) if not
-; IN/OUT: D6.l - Reference to dos.library
+; IN/OUT: A6.l - Reference to dos.library
 ;-----------------------------------------------------------
 ; Overwrites D0, D1, A0, A1
 ;-----------------------------------------------------------
@@ -1591,7 +1705,7 @@ _LVODeleteFile = -72
 
     move.l d2,-(sp) ; preserve registers
 
-    lea .deleteFile,a0  ; return address in A0
+    lea .deleteFile(pc),a0  ; return address in A0
     bra GetEnvVarPath
 
 .deleteFile
@@ -1615,7 +1729,7 @@ _LVODeleteFile = -72
 ;-----------------------------------------------------------
 ; IN      D1.l - address of null-terminated env. var. name
 ; OUT:    D0.l - TRUE (-1) if successful, FALSE (0) if not
-; IN/OUT: D6.l - Reference to dos.library
+; IN/OUT: A6.l - Reference to dos.library
 ;-----------------------------------------------------------
 ; Overwrites D0, D1, A0, A1
 ;-----------------------------------------------------------

--- a/source/sysvars.S
+++ b/source/sysvars.S
@@ -1,6 +1,6 @@
 ************************************************************
 *                                                          *
-*                      SYSVARS V.0.23                      *
+*                      SYSVARS V.0.19                      *
 *                                                          *
 * SPDX-FileCopyrightText: (c) 2023-2025 Lars Stockmann     *
 * SPDX-License-Identifier: MIT                             *
@@ -13,7 +13,7 @@
 ************************************************************
 
 PROGVER: macro
-    dc.b "$VER: SYSVARS 0.23",0
+    dc.b "$VER: SYSVARS 0.19",0
     endm
 
 ******************** Feature Selection *********************
@@ -111,17 +111,11 @@ Line1111EmulatorVector      EQU $2c
 
 CPU_68000   EQU 0
 CPU_68010   EQU 1
-CPU_68EC020 EQU 2
-CPU_68020   EQU 3
-CPU_68EC030 EQU 4
-CPU_68030   EQU 5
-CPU_68EC040 EQU 6
-CPU_68LC040 EQU 7
-CPU_68040   EQU 8
-CPU_68EC060 EQU 9
-CPU_68LC060 EQU 10
-CPU_68060   EQU 11
-CPU_68080   EQU 12
+CPU_68020   EQU 2
+CPU_68030   EQU 3
+CPU_68040   EQU 4
+CPU_68060   EQU 6
+CPU_68080   EQU 8
 
 FPU_NONE    EQU 0
 FPU_68881   EQU 1
@@ -141,10 +135,6 @@ PCRF_DPF EQU 1<<1
 CACRB_ED EQU 8
 CACRF_ED EQU 1<<8
 
-; cache control no allocate mode (68060)
-CACRB_NAI EQU 14
-CACRF_NAI EQU 1<<14
-
 ; cache control instruction cache enable (68040+)
 CACRB_IE EQU 15
 CACRF_IE EQU 1<<15
@@ -152,12 +142,7 @@ CACRF_IE EQU 1<<15
 AC68080_ID EQU $0440
 MC68060_ID EQU $0430
 
-; constants for detection of 24bit addressing
-KICK_VER equ $00F8000C
-KICK_VER_WRAP equ 1<<24
-
 ; Exec Constants and _LVOs
-
 EXEC_BASE      = 4
 EXEC_Node_SIZE = 14
 EXEC_LIB_HDR_S = EXEC_Node_SIZE+20
@@ -170,15 +155,13 @@ _LVOCloseLibrary = -414
 _LVOOpenResource = -498
 _LVOOpenLibrary  = -552
 
+_LVOAttnFlags = $128
 _LVOResourceList = $150
 
 ; expansion.library
 _LVOFindConfigDev = -72
-musashi_mid equ $7db
-musashi_interaction_pid equ $6b
-
-
-_LVOAttnFlags = $128
+musashi_mid EQU $7db
+musashi_interaction_pid EQU $6b
 
 ; Dos _LVOs
 
@@ -191,6 +174,16 @@ GVF_LOCAL_ONLY = $200
 
 ************************* Macros  **************************
 
+
+;-----------------------------------------------------------
+; get's exec.library base address to passed address register
+;-----------------------------------------------------------
+; Macro Arguments:
+; 1: address register to store the exec.library address in
+;-----------------------------------------------------------
+EXECBASE macro
+	movea.l EXEC_BASE.w,\1
+  endm
 
 ;-----------------------------------------------------------
 ; Uses the sysvars naming scheme to generate environment
@@ -374,7 +367,7 @@ OPEN_LIBRARY: macro
         movea.l a6,\3
     endc
 
-    movea.l EXEC_BASE.w,a6         ; get exec base in A6
+    EXECBASE a6         ; get exec base in A6
     jsr     _LVOOpenLibrary(a6)
     ifnc "\3",""
         movea.l \3,a6
@@ -414,7 +407,7 @@ CLOSE_LIBRARY: macro
             movea.l a6,\2
         endc
 
-    movea.l EXEC_BASE.w,a6          ; get exec base in A6
+    EXECBASE a6         ; get exec base in A6
     jsr     _LVOCloseLibrary(a6)
     ifnc "\2",""
         movea.l \2,a6
@@ -483,7 +476,7 @@ _LVOSoftVer   = $14
 
     ; On KS < 1.2, we detect that here and fetch the version
     ; via _LVOSoftVer of EXEC.
-    movea.l EXEC_BASE.w,a0            ; get exec base in A0
+    EXECBASE a6                     ; get exec base in A6
     move.w  _LVOSoftVer(a0),d5      ; get KS version
     SET_NUMERIC_ENV_VAR KickVer,d5
     SET_ENV_VAR KickRev
@@ -523,15 +516,20 @@ _LVOSoftVer   = $14
 ;-----------------------------------------------------------
 setCPUAndFPUEnvVars:
     ; detect CPU
-    movea.l EXEC_BASE.w,a0  ; get exec base in A0
+    EXECBASE a0             ; get exec base in A0
     lea .detectCPU(pc),a5   ; fetch pointer to function
     jsr _LVOSupervisor(a0)  ; execute function in supervisor
                             ; mode
-    lea .cpuType,a3
-    move.b d7,(a3)
+
+    move.l  d7,d0
+    add.l   #$30,d0         ; convert to ascii
+    lea     CPUStr,a0
+    move.b  d0,3(a0)
+    ; set cpu environment variable
+    SET_ENV_VAR CPU,#CPUStr
 
     ; detect FPU
-    movea.l EXEC_BASE.w,a0  ; get exec base in A0
+    EXECBASE a0             ; get exec base in A0
     move.l  d7,d1           ; recall cpu model
     lea .detectFPU(pc),a5
     jsr _LVOSupervisor(a0)
@@ -549,60 +547,24 @@ setCPUAndFPUEnvVars:
 .fpu68882:
 .fpu68881:
     move.b  d0,4(a0)
-    moveq   #5,d3
+    ; zero terminate the string
+    move.b  #0,5(a0)
     bra.s   .setFPUEnvVar
 .fpuNone:
-    ; 68040 without FPU are LC/EC variants
-    cmp.b   #CPU_68040,(a3)
-    bne.s   .noCPUModelAdjust
-    move.b  #CPU_68LC040,(a3)
-.noCPUModelAdjust
-    move.l  #"none",(a0)
-    moveq   #4,d3
-    bra.s   .setFPUEnvVar
+    DELETE_ENV_VAR FPU
+    bra.s   .end
 .fpuInternal:
     move.l #"inte",(a0)    ; "internal"
-    moveq  #8,d3
 .setFPUEnvVar:
-    SET_ENV_VAR FPU,#FPUStr,d3
+    SET_ENV_VAR FPU,#FPUStr
 
-.writeCPUString:
-    moveq   #0,d7
-    move.b  (a3),d7
-    move.l  d7,d0
-    mulu.w  #.cpuNameLength,d0
-    lea     .cpuName,a0
-    adda.l  d0,a0
-    SET_ENV_VAR CPU,a0
-
+    ; set CPU revision for MC68060/AC68080
     cmp.b #CPU_68040,d7
     ble.s .end
-    ; set CPU revision for MC68060/AC68080
     SET_NUMERIC_ENV_VAR CPURev,d6
 
 .end
     rts
-
-    section "VariableData",DATA
-.cpuType:
-    dc.b 0
-    cnop 0,2
-.cpuNameLength EQU 8
-.cpuName:
-    dc.b "68000",0,0,0
-    dc.b "68010",0,0,0
-    dc.b "68EC020",0
-    dc.b "68020",0,0,0
-    dc.b "68EC030",0
-    dc.b "68030",0,0,0
-    dc.b "68EC040",0
-    dc.b "68LC040",0
-    dc.b "68040",0,0,0
-    dc.b "68EC060",0
-    dc.b "68LC060",0
-    dc.b "68060",0,0,0
-    dc.b "68080",0
-    cnop 0,2
 
     section "Code",CODE
 
@@ -636,7 +598,7 @@ setCPUAndFPUEnvVars:
 ;-----------------------------------------------------------
 
 .detectCPU:
-    movea.l EXEC_BASE.w,a0
+    EXECBASE a0             ; get exec base in A0
 
     ; save Illegal Instruction vector from absolute address
     move.l  IllegalInstructionVector.w,d6
@@ -674,24 +636,10 @@ setCPUAndFPUEnvVars:
                             ; data cache
     jsr     .writeCACR(pc)
     btst    #CACRB_ED,d1
-    bne.s   .is030          ; it's 68030
-	; it's 68020 or 68ec020
-	; get kickstart version
-	movea.l #KICK_VER,a3
-	; and from same address with bit 24 set
-	; which wraps around on MC68EC020
-	movea.l #KICK_VER_WRAP,a4
-	add.l a3,a4
-	move.l (a3),d3
-	move.l (a4),d4
-	; compare kickstart versions
-	cmp.l d3,d4
-	bne.s .detectCPU_end
-	moveq #CPU_68EC020,d7
-    bra.s .detectCPU_end
-.is030:
-    moveq   #CPU_68030,d7
-    bra.s   .detectCPU_end  ; it's 68030
+    beq.s   .detectCPU_end  ; it's 68020
+
+	moveq   #CPU_68030,d7   ; it's 68030
+    bra.s   .detectCPU_end
 
 .is040:
     moveq   #CPU_68040,d7   ; assume 68040
@@ -707,11 +655,7 @@ setCPUAndFPUEnvVars:
     swap    d1
     cmp.w   #AC68080_ID,d1
     beq.s   .detectCPU_end  ; it's 68080
-    moveq   #CPU_68060,d7   ; assume 68060
-    andi.l  #$0000000F,d1
-    tst.l   d1
-    beq.s   .detectCPU_end
-    moveq   #CPU_68LC060,d7   ; it's 68LC060 or 68EC060
+    moveq   #CPU_68060,d7   ; it's 68060
     bra.s   .detectCPU_end
 
 .cleanupCPU
@@ -837,12 +781,14 @@ setCPUAndFPUEnvVars:
 
     section "VariableData",DATA
     
-CPUStr: dc.b "680?0"
+CPUStr:
+    dc.b "680?0",0
 
 ; The string for the FPU is composed using a long  move.
 ; Thus the target string must be aligned accordingly.
     cnop 0,4
-FPUStr: dc.b "6888rnal"
+FPUStr:
+    dc.b "6888rnal",0
     
     section "Strings",CODE
 
@@ -874,8 +820,8 @@ VAMP_VER_ADDR      = $dff3fc
 
 ; We skip the Vampire detection if no 68080 CPU is present.
 ; Thus, check again AttnFlags...
-    movea.l EXEC_BASE.w,a0          ; get exec base in A0
-    move.w  _LVOAttnFlags(a0),d5  ; get cpu info in D5
+    EXECBASE a0                     ; get exec base in A0
+    move.w  _LVOAttnFlags(a0),d5    ; get cpu info in D5
     btst    #10,d5
     bne.b   .haveVampire
 
@@ -1078,8 +1024,8 @@ mh_Attributes = $0e
 mh_Lower      = $14
 mh_Upper      = $18
 
-    movea.l EXEC_BASE.w,a0
-    move.l _LVOMemList(a0),d0  ; get memory list
+    EXECBASE a0                 ; get exec base in A0
+    move.l _LVOMemList(a0),d0   ; get memory list
 
 ; initialize registers
 ; Note: D0 - D3 are potentially overwritten by SET_ENV_VAR
@@ -1272,7 +1218,7 @@ setUAEEnvVars:
     ; save dos.library pointer
     movea.l a6,a4
     ; get exec.library
-    movea.l EXEC_BASE.w,a6
+    EXECBASE a6
 
     ; assume no emulation
     moveq #EMU_NONE,d7
@@ -1339,7 +1285,7 @@ setUAEEnvVars:
 .closeExpansion:
     ; get expansion.library pointer
     movea.l a6,a1
-    movea.l EXEC_BASE.w,a6
+    EXECBASE a6
     jsr _LVOCloseLibrary(a6)
 
 .writeEmuEnvVars

--- a/source/sysvars.S
+++ b/source/sysvars.S
@@ -101,6 +101,33 @@ E_\1 = 1
 FALSE =  0
 TRUE  = -1
 
+; exception vectors
+IllegalInstructionVector    EQU $10
+Line1111EmulatorVector      EQU $2c
+
+CPU_68000   EQU 0
+CPU_68010   EQU 1
+CPU_68EC020 EQU 2
+CPU_68020   EQU 3
+CPU_68EC030 EQU 4
+CPU_68030   EQU 5
+CPU_68EC040 EQU 6
+CPU_68LC040 EQU 7
+CPU_68040   EQU 8
+CPU_68EC060 EQU 9
+CPU_68LC060 EQU 10
+CPU_68060   EQU 11
+CPU_68080   EQU 12
+
+FPU_NONE    EQU 0
+FPU_68881   EQU 1
+FPU_68882   EQU 2
+FPU_INT     EQU 3
+
+; processor configuration register disable floating-point unit (68060)
+PCRB_DPF EQU 1
+PCRF_DPF EQU 1<<1
+
 ; cache control enable data cache (68030)
 CACRB_ED EQU 8
 CACRF_ED EQU 1<<8
@@ -109,7 +136,7 @@ CACRF_ED EQU 1<<8
 CACRB_NAI EQU 14
 CACRF_NAI EQU 1<<14
 
- ; cache control instruction cache enable (68040+)
+; cache control instruction cache enable (68040+)
 CACRB_IE EQU 15
 CACRF_IE EQU 1<<15
 
@@ -471,15 +498,66 @@ _LVOSoftVer   = $14
 ;-----------------------------------------------------------
 setCPUAndFPUEnvVars:
 
-; Test bits of second AttnFlags byte
     movea.l EXEC_BASE,a0          ; get exec base in A0
-    move.w  _LVOAttnFlags(a0),d5  ; get cpu info in D5
 
-; D4 gets the CPU version as ASCII character that replaces
+    lea .detectCPU(pc),a5   ; fetch pointer to function
+    jsr _LVOSupervisor(a0)  ; execute function in supervisor
+                            ; mode
+
+    move.l  d0,d7           ; store cpu model for later
+
+; D0 gets the CPU version as ASCII character that replaces
 ; the "?" in "680?0"
+    lea     .cpuDigit,a0
+    move.b  (a0,d0),d0
+    addi.l  #$30,d0         ; convert to ascii
+    move.b  d0,CPUStr+3     ; digit at position 3
+    SET_ENV_VAR_CLEN CPU,#CPUStr,5
 
+    movea.l EXEC_BASE,a0    ; get exec base in A0
+    move.l  d7,d1           ; recall cpu model
+    lea .detectFPU(pc),a5
+    jsr _LVOSupervisor(a0)
+
+; D0 gets the FPU version as ASCII character that replaces
+; the "?" in "6888?" or the whole string gets mangled
+    lea     FPUStr,a0
+    cmp.l   #FPU_NONE,d0
+    beq.s   .fpuNone
+    cmp.l   #FPU_INT,d0
+    beq.s   .fpuInternal
+    add.l   #$30,d0         ; convert to ascii
+
+.fpu68882:
+.fpu68881:
+    move.b  d0,4(a0)
+    moveq   #5,d3
+    bra.s   .setFPUEnvVar
+.fpuNone:
+    move.l  #"none",(a0)
+    moveq   #4,d3
+    bra.s   .setFPUEnvVar
+.fpuInternal:
+    move.l #"inte",(a0)    ; "internal"
+    moveq  #8,d3
+.setFPUEnvVar:
+    SET_ENV_VAR FPU,#FPUStr,d3
+
+    rts
+
+    section "VariableData",DATA
+
+.cpuDigit:
+    dc.b 0,1,2,2,3,3,4,4,4,6,6,6,8
+    cnop 0,2
+
+    section "Code",CODE
+
+;-----------------------------------------------------------
+; Determines the CPU type and returns it in register D0
+; This function must be called in supervisor mode
+;
 ; Based on code by
-
 ; Chris Hooper: detecting MC680x0 cpus by cleverly
 ; exploiting their CACR and PCR capabilities
 ; https://github.com/cdhooper/amigapci_stm32/blob/main/amiga/cpu_control.c
@@ -495,93 +573,187 @@ setCPUAndFPUEnvVars:
 ; Apollo AC68080 PROGRAMMER'S REFERENCE MANUAL
 ; telling the MC68060 and AC68080 apart by its PCR ID value
 ; http://www.apollo-core.com/documentation/AC68080PRM.pdf
+;
+;-----------------------------------------------------------
+; OUT: D0 - CPU type
+;-----------------------------------------------------------
+; Note: Doesn't preserve any registers
+;-----------------------------------------------------------
 
-    moveq #"0",d4           ; assume 68000
-    btst #0,d5              ; test for 68010+
-    beq.s .storeCPU         ; it's 68000
-    moveq #"1",d4           ; assume 68010
-    btst #1,d5              ; test for 68020+
-    beq.s .storeCPU         ; it's 68010
-    moveq #"2",d4           ; assume 68020
-    move.l #CACRF_IE,d1     ; CACR value to enable 68040+
+.detectCPU:
+    movea.l EXEC_BASE,a0
+
+    ; save Illegal Instruction vector from absolute address
+    move.l  IllegalInstructionVector.w,d6
+    ; install Illegal Instruction trap on absolute address
+    lea     .illegalInstructionTrap(pc),a0
+    move.l  a0,IllegalInstructionVector.w
+
+    moveq   #CPU_68000,d7   ; assume 68000
+    ; execute instruction illegal on MC68000
+    dc.w    $4e7a,$0801     ; movec vbr,d0
+
+    tst.l   d0              ; check for zero VBR
+    beq.s   .zeroVBR
+
+    ; install Illegal Instruction trap on vbr address
+    movea.l d0,a1
+    move.l  IllegalInstructionVector(a1),d5
+    move.l  a0,IllegalInstructionVector.w(a1)
+
+.zeroVBR:
+    moveq   #CPU_68010,d7   ; assume 68010
+    ; execute instruction illegal on MC68010
+    dc.w    $4e7a,$0002     ; movec cacr,d0
+
+    moveq   #CPU_68020,d7   ; assume 68020
+    move.l  #CACRF_IE,d1    ; CACR value to enable 68040+
                             ; instruction cache
-    lea .writeCACR(pc),a5   ; fetch pointer to function
-    jsr _LVOSupervisor(a0)  ; execute function in supervisor
-                            ; mode
-    btst #CACRB_IE,d1       ; test for 68040
-    bne.s .is040
-    move.l #CACRF_ED,d1     ; CACR value to enable 68030
+    jsr     .writeCACR(pc)
+
+    btst    #CACRB_IE,d1    ; test for 68040
+    bne.s   .is040
+
+    ; it's either 68020 or 68030
+    move.l  #CACRF_ED,d1    ; CACR value to enable 68030
                             ; data cache
-    jsr _LVOSupervisor(a0)  ; execute function in
-                            ; supervisor mode
-    btst #CACRB_ED,d1
-    beq.s .storeCPU         ; it's 68020
-    moveq #"3",d4
-    bra.s .storeCPU         ; it's 68030
+    jsr     .writeCACR(pc)
+    btst    #CACRB_ED,d1
+    beq.s   .detectCPU_end  ; it's 68020
+    moveq   #CPU_68030,d7
+    bra.s   .detectCPU_end  ; it's 68030
+
 .is040:
-    moveq #"4",d4           ; assume 68040
-    move.l #CACRF_NAI,d1    ; CACR value to enable 68060
+    moveq   #CPU_68040,d7   ; assume 68040
+    move.l  #CACRF_NAI,d1   ; CACR value to enable 68060
                             ; no allocation mode
-    jsr _LVOSupervisor(a0)  ; execute function in
-                            ; supervisor mode
-    btst #CACRB_NAI,d1
-    beq.s .storeCPU         ; it's 68040
-    moveq #"6",d4           ; assume 68060
-    lea .readPCR(pc),a5     ; fetch pointer to function
-    jsr _LVOSupervisor(a0)  ; execute function in
-                            ; supervisor mode
+    jsr     .writeCACR(pc)
+
+    btst    #CACRB_NAI,d1
+    beq.s   .detectCPU_end  ; it's 68040
+    moveq   #CPU_68060,d7   ; assume 68060
+    dc.w    $4e7a,$1808     ; hex for 'movec.l pcr, d1 ; read pcr
+
     swap d1
-    and.l #$0000FFF0,d1
-    cmp.w #AC68080_ID,d1
-    bne.s .storeCPU         ; it's 68060
-    moveq #"8",d4           ; it's 68080
+    and.l   #$0000FFF0,d1
+    cmp.w   #AC68080_ID,d1
+    bne.s   .detectCPU_end  ; it's 68060
+    moveq   #CPU_68080,d7   ; it's 68080
 
-.storeCPU:
-    move.b  d4,CPUStr+3            ; digit at position 3
-    SET_ENV_VAR_CLEN CPU,#CPUStr,5
+.cleanupCPU
+    ; restore Illegal Instruction vector on absolute address
+    move.l  d6,IllegalInstructionVector.w
+    tst.l   d7
+    beq.s   .detectCPU_end
 
-; Only consider checking FPU if CPU > 68010
-    cmpi.b  #'1',d4 ; Check for 68010
-    bhi .mayHaveFPU    
-    rts
+    ; check if Illegal Instruction vector on VBR address needs to be restored 
+    dc.w    $4e7a,$1801     ; movec vbr,d1
+    tst.l   d1
+    beq.s   .detectCPU_end
 
-.writeCACR:
-    dc.w $4e7a,$0002  ; hex for 'movec.l cacr, d0' ; save cacr
-    dc.w $4e7b,$1002  ; hex for 'movec.l d1, cacr' ; write cacr
-    dc.w $4e7a,$1002  ; hex for 'movec.l cacr, d1' ; read cacr back
-    dc.w $4e7b,$0002  ; hex for 'movec.l d0, cacr' ; restore cacr
+    ; restore Illegal Instruction vector on VBR address
+    move.l  d1,a1
+    move.l  d5,IllegalInstructionVector(a1)
+.detectCPU_end
+    move.l  d7,d0
     rte
 
-.readPCR:
-    dc.w $4e7a,$1808  ; hex for 'movec.l pcr, d1 ; read pcr
+.illegalInstructionTrap:
+    tst.l   d7
+    bne.s   .sixWordFrame
+; 68000 generates 4 word stack frames on exception (Four-Word Stack Frame, Format $0)
+.fourWordFrame
+    addq.l  #$6,sp
+    bra.s   .cleanupCPU
+; 68010+ generate 6 word stack frames on exception (Six-Word Stack Frame, Format $2)
+.sixWordFrame
+    addq.l  #$8,sp
+    bra.s   .cleanupCPU
+
+.writeCACR
+    dc.w    $4e7a,$0002     ; hex for 'movec.l cacr, d0' ; save cacr
+    dc.w    $4e7b,$1002     ; hex for 'movec.l d1, cacr' ; write cacr
+    dc.w    $4e7a,$1002     ; hex for 'movec.l cacr, d1' ; read cacr back
+    dc.w    $4e7b,$0002     ; hex for 'movec.l d0, cacr' ; restore cacr
+    rts
+
+;-----------------------------------------------------------
+; Determines the FPU type and FPU version, returns them in
+; registers D0 and D1
+; This function must be called in supervisor mode
+;
+; Based on information obtained from:
+; 1. MOTOROLA M68000 FAMILY Programmer’s Reference Manual Rev.1
+; 2. M68060 User’s Manual
+; 3. MC68881/882 Floating-point Coprocessor User's Manual Second Edition
+;
+;-----------------------------------------------------------
+; IN:  D1 - CPU type
+; OUT: D0 - FPU type
+;      D1 - FPU version
+;-----------------------------------------------------------
+; Note: Doesn't preserve any registers
+;-----------------------------------------------------------
+.detectFPU:
+    move.l  d1,d7
+
+    cmp.l   #CPU_68060,d7
+    blo.s   .no060
+    ; try enabling fpu on MC68060
+    dc.w    $4e7a,$0808     ; hex for 'movec.l pcr, d0 ; read pcr
+    and.b   #(~PCRF_DPF),d0
+    dc.w    $4e7b,$0808     ; hex for 'movec.l d0, pcr ; write pcr
+
+.no060:
+    ; save Line 1111 Emulator (Unimplemented F-Line Opcode) vector
+    move.l  Line1111EmulatorVector.w,d3
+    lea     .line1111Trap(pc),a0
+    move.l  a0,Line1111EmulatorVector.w
+
+    ; check for any fpu
+    moveq   #FPU_NONE,d0    ; assume no fpu
+    dc.w    $f280,$0000     ; fnop
+
+    moveq   #1,d0           ; assume mc68881
+    dc.w    $f327           ; fsave -(sp)
+    moveq   #0,d1
+    moveq   #0,d2
+    move.b  (sp),d1         ; get fpu version
+    move.b  1(sp),d2        ; get state frame size
+    dc.w    $f35f           ; frestore (sp)+
+    cmpi    #$18,d2         ; MC68881 idle state frame size is $18
+    beq.s   .cleanup
+    cmpi    #$38,d2         ; MC68882 idle state frame size is $38
+    beq.s   .mc68882
+    tst.w   d2              ; MC68040 idle state frame size is $00
+                            ; MC68060 has a different frame format
+    beq.s   .internal
+    moveq   #0,d0           ; assume no fpu
+    beq.s   .cleanup
+
+.internal
+    moveq   #FPU_INT,d0     ; internal 68040/68060/68080 fpu
+    bra.s   .cleanup
+
+.mc68882
+    moveq   #FPU_68882,d0   ; mc68882 fpu
+
+.cleanup
+    ; restore Line 1111 Emulator (Unimplemented F-Line Opcode) vector
+    move.l  d3,Line1111EmulatorVector.w
     rte
 
-.mayHaveFPU:
-; We lshift D0 by 1 (via add.b D5,D5) until it is negative
-    lea    FPUStr,a0
-    add.b  d5,d5
-    bmi.b  .storeInternal
-    add.b  d5,d5
-    bmi.b  .store68882
-    add.b  d5,d5
-    bmi.b  .store68881
-; nothing to store
-    moveq  #0,d3
-    bra.b  .setFPUEnvVar
-.storeInternal:
-    move.l #"inte",(a0)    ; "internal"
-    moveq  #8,d3
-    bra.b  .setFPUEnvVar
-.store68882:
-    move.b #"2",4(a0)
-    moveq  #5,d3
-    bra.b  .setFPUEnvVar
-.store68881:
-    move.b #"1",4(a0)
-    moveq  #5,d3
-.setFPUEnvVar:
-    SET_ENV_VAR FPU,#FPUStr,d3
-    rts
+.line1111Trap:
+    cmp.l   #CPU_68040,d7
+    blo.s   .sixwordframe
+; MC68EC040 and MC68LC040 Floating-Point Unimplemented Stack Frame, Format $4
+.eightwordframe
+    add.l   #$10,sp
+    bra.s   .cleanup
+; all other cpus without fpu generate 6 word stack frames on exception (Six-Word Stack Frame, Format $2)
+.sixwordframe
+    addq.l  #$8,sp
+    bra.s   .cleanup
 
     section "VariableData",DATA
     

--- a/source/sysvars.S
+++ b/source/sysvars.S
@@ -1,6 +1,6 @@
 ************************************************************
 *                                                          *
-*                      SYSVARS V.0.17                      *
+*                      SYSVARS V.0.18                      *
 *                                                          *
 * SPDX-FileCopyrightText: (c) 2023-2025 Lars Stockmann     *
 * SPDX-License-Identifier: MIT                             *
@@ -13,7 +13,7 @@
 ************************************************************
 
 PROGVER: macro
-    dc.b "$VER: SYSVARS 0.17",0
+    dc.b "$VER: SYSVARS 0.18",0
     endm
 
 ******************** Feature Selection *********************
@@ -101,6 +101,18 @@ E_\1 = 1
 FALSE =  0
 TRUE  = -1
 
+; cache control enable data cache (68030)
+CACRB_ED EQU 8
+CACRF_ED EQU 1<<8
+
+; cache control no allocate mode (68060)
+CACRB_NAI EQU 14
+CACRF_NAI EQU 1<<14
+
+ ; cache control instruction cache enable (68040+)
+CACRB_IE EQU 15
+CACRF_IE EQU 1<<15
+
 ; Exec Constants and _LVOs
 
 EXEC_BASE      =  4
@@ -108,6 +120,7 @@ EXEC_Node_SIZE = 14
 EXEC_LIB_HDR_S = EXEC_Node_SIZE+20
 EXEC_O_LIB_VER = EXEC_Node_SIZE+6
 
+_LVOSupervisor = -30
 _LVOOpenLibrary  = -552
 _LVOCloseLibrary = -414
 
@@ -462,35 +475,58 @@ setCPUAndFPUEnvVars:
 
 ; D4 gets the CPU version as ASCII character that replaces
 ; the "?" in "680?0"
-    moveq #"8",d4    ; assume 68080
-    btst  #10,d5
-    bne.b .storeCPU
-    moveq #"6",d4    ; assume 68060
-    btst  #7,d5
-    bne.b .storeCPU
-    moveq #"4",d4    ; assume 68040
-    btst  #3,d5
-    bne.b .storeCPU
-    moveq #"3",d4    ; assume 68030
-    btst  #2,d5
-    bne.b .storeCPU
-    moveq #"2",d4    ; assume 68020
-    btst  #1,d5
-    bne.b .storeCPU
-    moveq #"1",d4    ; assume 68010
-    btst  #0,d5
-    bne.b .storeCPU
-    moveq #"0",d4    ; it must be 68000    
-    
+    moveq #"0",d4           ; assume 68000
+    btst #0,d5              ; test for 68010+
+    beq.s .storeCPU         ; it's 68000
+    moveq #"1",d4           ; assume 68010
+    btst #1,d5              ; test for 68020+
+    beq.s .storeCPU         ; it's 68010
+    moveq #"2",d4           ; assume 68020
+    move.l #CACRF_IE,d1     ; CACR value to enable 68040+ instruction cache
+    lea .writeCACR(pc),a5   ; fetch pointer to function
+    jsr _LVOSupervisor(a0)  ; execute function in supervisor mode
+    btst #CACRB_IE,d1       ; test for 68040
+    bne.s .is040
+    move.l #CACRF_ED,d1      ; CACR value to enable 68030 data cache
+    jsr _LVOSupervisor(a0)  ; execute function in supervisor mode
+    btst #CACRB_ED,d1
+    beq.s .storeCPU         ; it's 68020
+    moveq #"3",d4
+    bra.s .storeCPU         ; it's 68030
+.is040:
+    moveq #"4",d4           ; assume 68040
+    move.l #CACRF_NAI,d1      ; CACR value to enable 68060 no allocation mode
+    jsr _LVOSupervisor(a0)  ; execute function in supervisor mode
+    btst #CACRB_NAI,d1
+    beq.s .storeCPU         ; it's 68040
+    moveq #"6",d4           ; assume 68060
+    lea .readPCR(pc),a5     ; fetch pointer to function
+    jsr _LVOSupervisor(a0)  ; execute function in supervisor mode
+    swap d1
+    and.l #$0000FFF0,d1
+    cmp.w #$0440,d1
+    bne.s .storeCPU         ; it's 68060
+    moveq #"8",d4           ; it's 68080
+
 .storeCPU:
     move.b  d4,CPUStr+3            ; digit at position 3
     SET_ENV_VAR_CLEN CPU,#CPUStr,5
-
 
 ; Only consider checking FPU if CPU > 68010
     cmpi.b  #'1',d4 ; Check for 68010
     bhi .mayHaveFPU    
     rts
+
+.writeCACR:
+    dc.w $4e7a,$0002  ; hex for 'movec.l cacr, d0' ; save cacr
+    dc.w $4e7b,$1002  ; hex for 'movec.l d1, cacr' ; write cacr
+    dc.w $4e7a,$1002  ; hex for 'movec.l cacr, d1' ; read cacr back
+    dc.w $4e7b,$0002  ; hex for 'movec.l d0, cacr' ; restore cacr
+    rte
+
+.readPCR:
+    dc.w $4e7a,$1808  ; hex for 'movec.l pcr, d1 ; read pcr
+    rte
 
 .mayHaveFPU:
 ; We lshift D0 by 1 (via add.b D5,D5) until it is negative

--- a/source/sysvars.S
+++ b/source/sysvars.S
@@ -1,6 +1,6 @@
 ************************************************************
 *                                                          *
-*                      SYSVARS V.0.19                      *
+*                      SYSVARS V.0.20                      *
 *                                                          *
 * SPDX-FileCopyrightText: (c) 2023-2025 Lars Stockmann     *
 * SPDX-License-Identifier: MIT                             *
@@ -13,7 +13,7 @@
 ************************************************************
 
 PROGVER: macro
-    dc.b "$VER: SYSVARS 0.19",0
+    dc.b "$VER: SYSVARS 0.20",0
     endm
 
 ******************** Feature Selection *********************
@@ -88,6 +88,8 @@ E_\1 = 1
     CHECK_ENABLED BSDSockLibRev
     CHECK_ENABLED BSDSockLib
 
+    CHECK_ENABLED Emu
+
     CHECK_ENABLED UAEMajor
     CHECK_ENABLED UAEMinor
     CHECK_ENABLED UAERev
@@ -144,7 +146,7 @@ AC68080_ID EQU $0440
 
 ; Exec Constants and _LVOs
 
-EXEC_BASE      =  4
+EXEC_BASE      = 4
 EXEC_Node_SIZE = 14
 EXEC_LIB_HDR_S = EXEC_Node_SIZE+20
 EXEC_O_LIB_VER = EXEC_Node_SIZE+6
@@ -349,7 +351,7 @@ OPEN_LIBRARY: macro
         movea.l a6,\3
     endc
 
-    movea.l EXEC_BASE,a6         ; get exec base in A6
+    movea.l EXEC_BASE.w,a6         ; get exec base in A6
     jsr     _LVOOpenLibrary(a6)
     ifnc "\3",""
         movea.l \3,a6
@@ -389,7 +391,7 @@ CLOSE_LIBRARY: macro
             movea.l a6,\2
         endc
 
-    movea.l EXEC_BASE,a6          ; get exec base in A6
+    movea.l EXEC_BASE.w,a6          ; get exec base in A6
     jsr     _LVOCloseLibrary(a6)
     ifnc "\2",""
         movea.l \2,a6
@@ -458,7 +460,7 @@ _LVOSoftVer   = $14
 
     ; On KS < 1.2, we detect that here and fetch the version
     ; via _LVOSoftVer of EXEC.
-    movea.l EXEC_BASE,a0            ; get exec base in A0
+    movea.l EXEC_BASE.w,a0            ; get exec base in A0
     move.w  _LVOSoftVer(a0),d5      ; get KS version
     SET_NUMERIC_ENV_VAR KickVer,d5
     SET_ENV_VAR KickRev
@@ -498,7 +500,7 @@ _LVOSoftVer   = $14
 ;-----------------------------------------------------------
 setCPUAndFPUEnvVars:
 
-    movea.l EXEC_BASE,a0          ; get exec base in A0
+    movea.l EXEC_BASE.w,a0          ; get exec base in A0
 
     lea .detectCPU(pc),a5   ; fetch pointer to function
     jsr _LVOSupervisor(a0)  ; execute function in supervisor
@@ -514,7 +516,7 @@ setCPUAndFPUEnvVars:
     move.b  d0,CPUStr+3     ; digit at position 3
     SET_ENV_VAR_CLEN CPU,#CPUStr,5
 
-    movea.l EXEC_BASE,a0    ; get exec base in A0
+    movea.l EXEC_BASE.w,a0    ; get exec base in A0
     move.l  d7,d1           ; recall cpu model
     lea .detectFPU(pc),a5
     jsr _LVOSupervisor(a0)
@@ -581,7 +583,7 @@ setCPUAndFPUEnvVars:
 ;-----------------------------------------------------------
 
 .detectCPU:
-    movea.l EXEC_BASE,a0
+    movea.l EXEC_BASE.w,a0
 
     ; save Illegal Instruction vector from absolute address
     move.l  IllegalInstructionVector.w,d6
@@ -800,7 +802,7 @@ VAMP_VER_ADDR      = $dff3fc
 
 ; We skip the Vampire detection if no 68080 CPU is present.
 ; Thus, check again AttnFlags...
-    movea.l EXEC_BASE,a0          ; get exec base in A0
+    movea.l EXEC_BASE.w,a0          ; get exec base in A0
     move.w  _LVOAttnFlags(a0),d5  ; get cpu info in D5
     btst    #10,d5
     bne.b   .haveVampire
@@ -1004,7 +1006,7 @@ mh_Attributes = $0e
 mh_Lower      = $14
 mh_Upper      = $18
 
-    movea.l EXEC_BASE,a0
+    movea.l EXEC_BASE.w,a0
     move.l _LVOMemList(a0),d0  ; get memory list
 
 ; initialize registers
@@ -1195,23 +1197,30 @@ BSDSockLibName: dc.b "bsdsocket.library",0
 ; Potentially overwrites all registers, except A6
 ;-----------------------------------------------------------
 setUAEEnvVars:
-
+_LVOFindConfigDev EQU -72
+_LVOOpenResource EQU -498
 _LVOResourceList = $150
 _LVOFindName     = -276
+musashi_mid equ $7db
+musashi_interaction_pid equ $6b
+
+    movea.l a6,a4
+    movea.l EXEC_BASE.w,a6
+
+; try to open UAE's uae.resource
+    moveq #0,d0
+    lea UaeResName,a1
+    jsr _LVOOpenResource(a6)
+    tst.l d0
+    beq.w .notUAE
 
 ; UAE structure embeds a library structure, after that it
 ; holds three words: major,; minor and revision
-
-    movea.l a6,a4 ; preserve A6 (needed for SysBase)   
-    movea.l EXEC_BASE,a6             ; get exec base in A6
+.readUAEVersions:
     lea     _LVOResourceList(a6),a0  ; arg1 resource list
     lea     UaeResName,a1            ; arg2 resource name
     jsr     _LVOFindName(a6)         ; call FindName
-    movea.l a4,a6 ; restore A6
-
-; Test whether UAE was detected
-    tst.l d0
-    beq   .notFound
+    movea.l a4,a6                    ; restore A6
 
 ; Store version as string in UAEEnvVarCont    
     move.l  d0,a3               ; addr. of UAE struct in A2
@@ -1226,18 +1235,67 @@ _LVOFindName     = -276
     moveq  #0,d0
     move.w (a3)+,d0
     SET_NUMERIC_ENV_VAR UAERev,d0
-    rts
+    SET_ENV_VAR_CLEN Emu,#UAEStr,3
+    bra.w .exit
 
-.notFound:
+.notUAE:
     DELETE_ENV_VAR UAEMajor
     DELETE_ENV_VAR UAEMinor
     DELETE_ENV_VAR UAERev
+
+; try to open Emu68's devicetree.resource
+    lea Emu68ResName,a1
+    jsr _LVOOpenResource(a6)
+    tst.l d0
+    beq.s .notEmu68
+
+    SET_ENV_VAR_CLEN Emu,#Emu68Str,5
+    bra.s .restoreA6
+
+.notEmu68:
+; try to find Musashi's interaction device
+    moveq #0,d0
+    lea.l expansionName,a1
+    jsr _LVOOpenLibrary(a6)
+    tst.l d0
+    ; quit if expansion.library couldn't be opened
+    beq.s .restoreA6
+
+    movea.l d0,a6
+	move.l #musashi_mid,d0
+	moveq #musashi_interaction_pid,d1
+    jsr _LVOFindConfigDev(a6)
+    tst.l d0
+    beq.s .restoreA6
+
+    SET_ENV_VAR_CLEN Emu,#MusashiStr,7
+
+.restoreA6:
+    movea.l a4,a6
+.exit
     rts
 
     section "Strings",CODE
+expansionName:
+    dc.b "expansion.library",0
+    cnop 0,2
+UaeResName:
+    dc.b "uae.resource",0
+    cnop 0,2
+Emu68ResName:
+    dc.b "devicetree.resource",0
+    cnop 0,2
+UAEStr:
+    dc.b "UAE"
+    cnop 0,2
+MusashiStr:
+    dc.b "Musashi"
+    cnop 0,2
+Emu68Str:
+    dc.b "Emu68"
+    cnop 0,2
 
-UaeResName: dc.b "uae.resource",0
-
+    DEFINE_ENV_VAR Emu
     DEFINE_ENV_VAR UAEMajor
     DEFINE_ENV_VAR UAEMinor
     DEFINE_ENV_VAR UAERev


### PR DESCRIPTION
Rewrote CPU and FPU detection which now should be OS independent. Veryfied working on OS3.1 and WinUAE only though.
- Support for FPU version added, not exposed yet.
- Support for EC/LC variants of MC68040/MC68060 added, though not exposed yet. Reason is really that the MMU detection code is not yet implemented.
- FPU get's set to "none" if no FPU is found